### PR TITLE
Fix crash when view definition doesn't yield parseable underlying table.

### DIFF
--- a/lib/perl/TuningManager/ExternalTable.pm
+++ b/lib/perl/TuningManager/ExternalTable.pm
@@ -204,8 +204,13 @@ SQL
     my ($viewText) = $stmt->fetchrow_array();
     $stmt->finish();
 
-    $viewText =~ m/[.\r\n]*\bfrom\b\s*(\w*)\.(\w*)[.\r\n]*/i;
+    $viewText =~ m/\bfrom\b\s+"?(\w+)"?\."?(\w+)"?/i;
     $schema = $1; $table = $2;
+
+    if (!$schema || !$table) {
+      TuningManager::TuningManager::Log::addLog("Cannot determine underlying table for view $self->{schema}.$self->{table}; skipping modification_date trigger check.");
+      return;
+    }
   }
 
   # check for a trigger


### PR DESCRIPTION
Updated regex to handle quoted identifiers and added a guard to log and return gracefully instead of generating invalid trigger SQL with empty schema/table names.